### PR TITLE
Provider version constraints is deprecated now.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,6 @@ data "terraform_remote_state" "network" {
 }
 
 provider "aws" {
-  version = "~> 2.7"
   region  = data.terraform_remote_state.network.outputs.aws_region
 }
 


### PR DESCRIPTION
The provider version constraints is deprecated, this change will remove the warning message from the plan output.